### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -11,34 +11,39 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Docker meta
       id: docker_meta
-      uses: crazy-max/ghaction-docker-meta@v1
+      uses: docker/metadata-action@v4
       with:
         images: ghcr.io/mganter/openstack-client
-        tag-semver: |
-            {{version}}
-            {{major}}.{{minor}}
+        tags: |
+          type=ref,event=branch
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
       with:
         platforms: all
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
       with:
         version: latest
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
+      if: ${{ github.event_name != 'pull_request' }}
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push
       id: docker_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: .
         file: ./Dockerfile

--- a/.github/workflows/periodic-release.yml
+++ b/.github/workflows/periodic-release.yml
@@ -3,49 +3,46 @@ name: new-version
 on:
   schedule:
   - cron:  '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
-  new-tag:
+ new-tag:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: oprypin/find-latest-tag@v1
+    - name: Find last tag
+      uses: oprypin/find-latest-tag@v1
       with:
         repository: ${{ github.repository }}
         releases-only: false  
-      id: previoustag  
-    - name: checkout tag
-      uses: actions/checkout@v2
+      id: previousTag  
+    - name: Checkout previous tag
+      uses: actions/checkout@v3
       with:
-        ref: ${{ steps.previoustag.outputs.tag }}
-    - name: get sha from commit
-      id: tagcommitsha
-      run: echo "::set-output name=sha::$(git rev-parse HEAD)"
-    - name: 'Get next patch version'
-      id: semvers
-      uses: "WyriHaximus/github-action-next-semvers@v1"
+        ref: ${{ steps.previousTag.outputs.tag }}
+        token: ${{ secrets.GH_PAT }}
+    - name: Get sha from commit
+      id: tagCommitSHA
+      run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+    - name: Get next patch version
+      id: nextTag
+      env: 
+        TAG: ${{ steps.previousTag.outputs.tag }}
+      run: |
+        wget -O ./semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
+        chmod +x ./semver
+        echo "nextPatch=$(./semver bump patch $TAG)" >> $GITHUB_OUTPUT
+    - name: Create new tag
+      uses: rickstaa/action-create-tag@v1
       with:
-        version: ${{ steps.previoustag.outputs.tag }}
-    - name: New Version
-      run: echo v${{ steps.semvers.outputs.patch }}
-    - name: Create tag
-      uses: actions/github-script@v3
-      with:
-        github-token: ${{ secrets.REGISTRY }}
-        script: |
-          github.git.createRef({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            ref: "refs/tags/v${{ steps.semvers.outputs.patch }}",
-            sha: "${{ steps.tagcommitsha.outputs.sha }}"
-          })
+        tag: v${{ steps.nextTag.outputs.nextPatch }}
+        commit_sha: ${{ steps.tagCommitSHA.outputs.sha }}
+        message: ""
     - name: Create Release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.REGISTRY }}
+      uses: ncipollo/release-action@v1
       with:
-        tag_name: v${{ steps.semvers.outputs.patch }}
-        release_name: Release v${{ steps.semvers.outputs.patch }}
+        token: ${{ secrets.GH_PAT }}
+        tag: v${{ steps.nextTag.outputs.nextPatch }}
+        name: Release v${{ steps.nexttag.outputs.nextPatch }}
         body: |
           This is an automatic release to update the packages inside the container
           The container image can be downloaded at ghrc.io


### PR DESCRIPTION
Hi @mganter,

I updated the github actions and there are some permission improvement for the github actions. Now also the periotic-release also should works again (Make sure to add one Tag/Release manually after merge this PR otherwise the new actions wont be active in the periotic-release).

1. To get this working you need to add a PAT (`Fine-grained personal access tokens`) and save this as `GH_PAT` in the repo secrets:
  - Select this repo (Only select repositories)
  - Repository permissions: 
    - `Metadata` - `read`
    - `Contents` - `read and write`

2. The old PAT (REGISTRY) is not needed anymore.

3. Enable the package (container) to be push able from the action:
  - go to the package (https://github.com/mganter/openstack-client-docker/pkgs/container/openstack-client)
  - package settings
  - add this repo to `Manage Actions access` with `write`

